### PR TITLE
Update TekkitRestrict/src/com/github/dreadslicer/tekkitrestrict/TRThread...

### DIFF
--- a/TekkitRestrict/src/com/github/dreadslicer/tekkitrestrict/TRThread.java
+++ b/TekkitRestrict/src/com/github/dreadslicer/tekkitrestrict/TRThread.java
@@ -291,16 +291,16 @@ class DisableItemThread extends Thread {
 					try {
 						oos = pp;
 
-						if (throttle) {
+						/*if (throttle) {
 							exe.execute((new Runnable() {
 								@Override
 								public void run() {
 									disableItems(oos);
 								}
 							}));
-						} else {
+						} else {*/
 							disableItems(pp);
-						}
+						//}
 					} catch (Exception e) {
 						TRLogger.Log(
 								"debug",


### PR DESCRIPTION
....java

Removed Ability for ItemDisabler to Multithread. (Fixes 100% CPU crash)
