### PR TITLE
Fix for error triggering on some /tr commands.

### DIFF
--- a/TekkitRestrict/src/com/github/dreadslicer/tekkitrestrict/commands/TRCommandTR.java
+++ b/TekkitRestrict/src/com/github/dreadslicer/tekkitrestrict/commands/TRCommandTR.java
@@ -215,7 +215,7 @@ public class TRCommandTR implements CommandExecutor {
 								}
 							}
 						} else if (args[1].equalsIgnoreCase("limit")) {
-							if (args[2] == null) {
+							if (args.length == 2) {
 								message.add("[TekkitRestrict "
 										+ tekkitrestrict.getInstance()
 												.getDescription().getVersion()
@@ -282,7 +282,7 @@ public class TRCommandTR implements CommandExecutor {
 							}
 						} else if (args[1].equalsIgnoreCase("emc")) {
 							// tempset, lookup
-							if (args[2] == null) {
+							if (args.length == 2) {
 								message.add("/tr admin emc tempset [id:data] [EMC]");
 								message.add("/tr admin emc lookup [id:data]");
 							} else if (args[2].equalsIgnoreCase("tempset")) {


### PR DESCRIPTION
If someone only types 2 arguments, then the args[] array from OnCommand only contains 2 arguments.
If you check for args[2] == null it will throw an arrayIndexOutOfBounds exeption because there are only 2 elements in the array.
