### PR TITLE
Java 1.7 Support & Banned Items Tweaked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.metadata/
+lib/
+.recommenders/

--- a/TekkitRestrict/.classpath
+++ b/TekkitRestrict/.classpath
@@ -6,9 +6,23 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Permission Plugins for Tekkit Classic"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Protection Plugins for Tekkit Classic"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Tekkit Classic Bukkit"/>
-	<classpathentry kind="lib" path="C:/Program Files/eclipse_Kepler/lib/Tekkit_Classic/Essentials 2.9.2 for 1.2.5.jar"/>
-	<classpathentry kind="lib" path="C:/Program Files/eclipse_Kepler/lib/Tekkit_Classic/EEPatch.zip"/>
-	<classpathentry kind="lib" path="org.eclipse.jdt.annotation_1.1.0.v20130513-1648.jar"/>
-	<classpathentry kind="lib" path="C:/Program Files/eclipse_Kepler/lib/Swing/jSuggestField.jar"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/eepatch.zip"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/Essentials.jar"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/PermissionsEx.jar"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Tekkit.jar"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/industrialcraft2-1.97-mcpc1.2.5-r7.zip"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/redpower-all-2.0p5b2-mcpc1.2.5-r15.zip"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/TekkitRestrict/org.eclipse.jdt.annotation_1.1.0.v20130513-1648.jar"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/EE2ServerV1.4.6.5-bukkit-mcpc-1.2.5-r5.zip"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/LWC.jar"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/bpermissions.jar"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/EssentialsGroupManager.jar"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/Vault.jar"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/WorldEdit.jar"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/WorldGuard.jar"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/PreciousStones.jar"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/Towny 0.82.0.0.jar"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/Factions.jar"/>
+	<classpathentry kind="lib" path="D:/Users/Robin/Downloads/Tekkit_Server_3.1.2/_/Factions.src/TekkitRestrict/lib/GriefPrevention.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/TekkitRestrict/.gitignore
+++ b/TekkitRestrict/.gitignore
@@ -1,5 +1,5 @@
 /bin
-/.classpath
-/.gitignore
-/.project
-/.directory
+.classpath
+.gitignore
+.project
+.directory

--- a/TekkitRestrict/src/nl/taico/tekkitrestrict/TRThread.java
+++ b/TekkitRestrict/src/nl/taico/tekkitrestrict/TRThread.java
@@ -390,8 +390,13 @@ class DisableItemThread extends Thread {
 						if (banned.equals("")) banned = ChatColor.RED + "Removed a banned item in your inventory: "+id+":"+data+".";
 						TRItem.sendBannedMessage(player, banned);
 						changedInv = true;
-						st1[i] = new ItemStack(Threads.ChangeDisabledItemsIntoId, 1);
-						continue; //Item is now dirt so continue with next one.
+						
+						ItemStack item = st1[i].clone();
+						st1[i] = null;
+						
+						player.getWorld().dropItem(player.getLocation(), item);
+						
+						continue; //Item is now dropped so continue with next one.
 					}
 					else if (checkEECharge(st1[i]) || checkCharge(st1[i])){
 						changedInv = true;
@@ -428,7 +433,12 @@ class DisableItemThread extends Thread {
 						if (banned.equals("")) banned = ChatColor.RED + "Removed banned armor from your inventory: "+id+":"+data+".";
 						TRItem.sendBannedMessage(player, banned);
 						changedArmor = true;
-						st2[i] = new ItemStack(Threads.ChangeDisabledItemsIntoId, 1); //proceed to remove it.
+						
+						ItemStack item = st2[i].clone();
+						st2[i] = null;
+						
+						player.getWorld().dropItem(player.getLocation(), item);
+
 						continue;
 					}
 					else if (checkCharge(st2[i])){

--- a/TekkitRestrict/src/nl/taico/tekkitrestrict/TRThread.java
+++ b/TekkitRestrict/src/nl/taico/tekkitrestrict/TRThread.java
@@ -391,10 +391,8 @@ class DisableItemThread extends Thread {
 						TRItem.sendBannedMessage(player, banned);
 						changedInv = true;
 						
-						ItemStack item = st1[i].clone();
+						player.getWorld().dropItem(player.getLocation(), st1[i]);
 						st1[i] = null;
-						
-						player.getWorld().dropItem(player.getLocation(), item);
 						
 						continue; //Item is now dropped so continue with next one.
 					}
@@ -434,11 +432,9 @@ class DisableItemThread extends Thread {
 						TRItem.sendBannedMessage(player, banned);
 						changedArmor = true;
 						
-						ItemStack item = st2[i].clone();
+						player.getWorld().dropItem(player.getLocation(), st2[i]);
 						st2[i] = null;
 						
-						player.getWorld().dropItem(player.getLocation(), item);
-
 						continue;
 					}
 					else if (checkCharge(st2[i])){

--- a/TekkitRestrict/src/nl/taico/tekkitrestrict/Updater.java
+++ b/TekkitRestrict/src/nl/taico/tekkitrestrict/Updater.java
@@ -259,7 +259,6 @@ public class Updater {
 	/**
 	 * Save an update from dev.bukkit.org into the server's update folder.
 	 */
-	@SuppressWarnings("resource")
 	private void saveFile(File folder, String file, String u) {
 		if (!folder.exists()) {
 			folder.mkdir();

--- a/TekkitRestrict/src/nl/taico/tekkitrestrict/database/MySQL.java
+++ b/TekkitRestrict/src/nl/taico/tekkitrestrict/database/MySQL.java
@@ -20,7 +20,6 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import nl.taico.tekkitrestrict.tekkitrestrict;
 
-@SuppressWarnings("resource")
 public class MySQL extends Database {
 	private String hostname = "localhost";
 	private String port = "3306";

--- a/TekkitRestrict/src/nl/taico/tekkitrestrict/database/SQLite.java
+++ b/TekkitRestrict/src/nl/taico/tekkitrestrict/database/SQLite.java
@@ -14,7 +14,6 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import nl.taico.tekkitrestrict.tekkitrestrict;
 
-@SuppressWarnings("resource")
 public class SQLite extends Database {
 	public String location;
 	public String name;

--- a/TekkitRestrict/src/nl/taico/tekkitrestrict/functions/TRNoItem.java
+++ b/TekkitRestrict/src/nl/taico/tekkitrestrict/functions/TRNoItem.java
@@ -1,7 +1,7 @@
 package nl.taico.tekkitrestrict.functions;
 
 import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -155,9 +155,9 @@ public class TRNoItem {
 		if (player.hasPermission(idStr+"."+data)) return "";
 		else if (player.hasPermission(idStr)) return "";
 		else {
-			Iterator<String> keys = TRItemProcessor.groups.keySet().iterator();
-			while (keys.hasNext()) {
-				String key = keys.next();
+			Enumeration<String> keys = TRItemProcessor.groups.keys();
+			while (keys.hasMoreElements()) {
+				String key = keys.nextElement();
 				if (player.hasPermission("tekkitrestrict.creative."+key)) {
 					List<TRItem> mi = TRItemProcessor.groups.get(key);
 					for(TRItem c:mi){
@@ -191,9 +191,9 @@ public class TRNoItem {
 		if (player.hasPermission(idStr+"."+data)) return "";
 		else if (player.hasPermission(idStr)) return "";
 		else {
-			Iterator<String> keys = TRItemProcessor.groups.keySet().iterator();
-			while (keys.hasNext()) {
-				String key = keys.next();
+			Enumeration<String> keys = TRItemProcessor.groups.keys();
+			while (keys.hasMoreElements()) {
+				String key = keys.nextElement();
 				if (player.hasPermission("tekkitrestrict.noitem."+key)) {
 					List<TRItem> mi = TRItemProcessor.groups.get(key);
 					for(TRItem c:mi){

--- a/TekkitRestrict/src/nl/taico/tekkitrestrict/functions/TRRecipeBlock.java
+++ b/TekkitRestrict/src/nl/taico/tekkitrestrict/functions/TRRecipeBlock.java
@@ -90,6 +90,7 @@ public class TRRecipeBlock {
 	public static boolean blockRecipeForge(int id, int data) {
 		boolean status = false;
 		// loop through recipes...
+		@SuppressWarnings("unchecked")
 		List<Object> recipes = CraftingManager.getInstance().recipies;
 
 		for (int i = 0; i < recipes.size(); i++) {

--- a/TekkitRestrict/src/nl/taico/tekkitrestrict/functions/TRSafeZone.java
+++ b/TekkitRestrict/src/nl/taico/tekkitrestrict/functions/TRSafeZone.java
@@ -186,7 +186,6 @@ public class TRSafeZone {
 	 * Gets a GriefPrevention SafeZone at the given location.<br>
 	 * Note: Does not actually get SafeZones from the database.
 	 */
-	@SuppressWarnings("unused")
 	@NonNull private static String getGPSafeZone(@NonNull Location loc){
 		if (griefPrevention == null) return "";
 		

--- a/TekkitRestrict/src/nl/taico/tekkitrestrict/gui/lib/JSuggestField.java
+++ b/TekkitRestrict/src/nl/taico/tekkitrestrict/gui/lib/JSuggestField.java
@@ -319,10 +319,12 @@ public class JSuggestField extends JTextField {
 	 *
 	 * @return Vector containing Strings
 	 */
+	@SuppressWarnings("unchecked")
 	public Vector<String> getSuggestData() {
 		return (Vector<String>) data.clone();
 	}
 	
+	@SuppressWarnings("unchecked")
 	public LinkedHashMap<String, TRItem> getData2(){
 		return (LinkedHashMap<String, TRItem>) data2.clone();
 	}

--- a/TekkitRestrict/src/nl/taico/tekkitrestrict/lib/config/FileConfiguration.java
+++ b/TekkitRestrict/src/nl/taico/tekkitrestrict/lib/config/FileConfiguration.java
@@ -118,7 +118,6 @@ public abstract class FileConfiguration extends MemoryConfiguration {
 	 * @throws IllegalArgumentException
 	 *             Thrown when file is null.
 	 */
-	@SuppressWarnings("resource")
 	public void load(File file) throws FileNotFoundException, IOException, InvalidConfigurationException {
 		Validate.notNull(file, "File cannot be null");
 

--- a/TekkitRestrict/src/nl/taico/tekkitrestrict/listeners/Assigner.java
+++ b/TekkitRestrict/src/nl/taico/tekkitrestrict/listeners/Assigner.java
@@ -24,8 +24,10 @@ public class Assigner {
 		
 		PM.registerEvents(new InventoryClickListener(), plugin);
 		
-		if (Listeners.UseNoItem)
+		if (Listeners.UseNoItem) {
 			CraftingListener.setupCraftHook();
+			PM.registerEvents(new ItemPickupListener(), plugin);
+		}
 		
 		if (Dupes.alcBags.prevent ||
 			Dupes.pedestals.prevent ||

--- a/TekkitRestrict/src/nl/taico/tekkitrestrict/listeners/ItemPickupListener.java
+++ b/TekkitRestrict/src/nl/taico/tekkitrestrict/listeners/ItemPickupListener.java
@@ -1,0 +1,41 @@
+package nl.taico.tekkitrestrict.listeners;
+
+import nl.taico.tekkitrestrict.functions.TRNoItem;
+
+import org.bukkit.GameMode;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerPickupItemEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class ItemPickupListener implements Listener {
+	
+	@EventHandler
+	public void onPlayerPickupItemEvent(PlayerPickupItemEvent ev) {
+		if(ev.isCancelled()) return;
+		
+		ItemStack item = ev.getItem().getItemStack();
+		Player player = ev.getPlayer();
+		
+		boolean bypassn = player.hasPermission("tekkitrestrict.bypass.noitem");
+		boolean bypassc = player.hasPermission("tekkitrestrict.bypass.creative");
+		boolean isCreative = (player.getGameMode() == GameMode.CREATIVE);
+		
+		String banned = null;
+		int id = item.getTypeId();
+		int data = item.getDurability();
+		
+		if (isCreative){
+			if (!bypassn) banned = TRNoItem.isItemBanned(player, id, data, false);
+			if (banned == null && !bypassc) banned = TRNoItem.isItemBannedInCreative(player, id, data, false);
+		} else {
+			if (!bypassn) banned = TRNoItem.isItemBanned(player, id, data, false);
+		}
+		
+		if (banned != null) {
+			ev.setCancelled(true);
+		}
+	}
+	
+}


### PR DESCRIPTION
The plugin had some problems supporting java 1.7. I also changed the way banned items are handled.. I didn't want to destroy an item that was banned. So when a player has a banned item in his inventory the item gets dropped now. He also won't be able to pick it up again.
